### PR TITLE
:sparkles: feat: ガチャの演出を強化し、ロジックを効率化

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import {
 import { useSound } from "use-sound";
 
 import { cities, prefectures } from "./constants";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import type { City, ColorSchemeType, Prefecture } from "./types";
 import drumLoop from "/noise-drum-loop.mp3?url";
 import crashCymbal from "/crash-cymbal.mp3?url";
@@ -42,6 +42,18 @@ function App() {
     Prefecture | undefined
   >(prefectures[0]);
 
+  const availableCities = useMemo(() => {
+    if (!pickedPrefecture) {
+      return [];
+    }
+    const pickedCityCodes = new Set(pickedCities.map((c) => c.city_code));
+    return cities.filter(
+      (city) =>
+        city.pref_code === pickedPrefecture.pref_code &&
+        !pickedCityCodes.has(city.city_code)
+    );
+  }, [pickedPrefecture, pickedCities]);
+
   const optionPrefectures = prefectures.map((prefecture) => ({
     value: prefecture.pref_code,
     label: prefecture.pref_name,
@@ -55,6 +67,7 @@ function App() {
       return;
     }
     setPickedCity(undefined);
+    setPickedCities([]);
     setPickedPrefecture(prefecture);
   };
 
@@ -78,130 +91,150 @@ function App() {
     const interval = setInterval(() => {
       const randomIndex = Math.floor(Math.random() * prefectures.length);
       setPickedPrefecture(prefectures[randomIndex]);
-    }, 10);
+    }, 50);
 
     return () => clearInterval(interval);
   }, [prefectureStart, isRandomPrefecture]);
 
   useEffect(() => {
-    if (!start || !pickedPrefecture) {
+    if (!start || availableCities.length === 0) {
+      if (start) {
+        setStart(false);
+      }
       return;
     }
-    const prefectureCity = cities.filter((city) => {
-      return city.pref_code === pickedPrefecture?.pref_code;
-    });
 
     const interval = setInterval(() => {
-      while (true) {
-        const currentCity =
-          prefectureCity[Math.floor(Math.random() * prefectureCity.length)];
-
-        if (
-          !pickedCities.find((city) => city.city_code === currentCity.city_code)
-        ) {
-          setPickedCity(currentCity);
-          break;
-        }
-      }
-    }, 10);
+      const randomIndex = Math.floor(Math.random() * availableCities.length);
+      setPickedCity(availableCities[randomIndex]);
+    }, 50);
 
     return () => clearInterval(interval);
-  }, [start, pickedPrefecture, pickedCities, pickedCity]);
+  }, [start, availableCities]);
 
   useEffect(() => {
-    if (pickedCities.length === 15) {
-      setStart(false);
+    if (pickedCity && !start && !pickedCities.find(c => c.city_code === pickedCity.city_code)) {
+      setPickedCities((prevPickedCities) => [...prevPickedCities, pickedCity]);
     }
-  }, [pickedCities]);
-
-  useEffect(() => {
-    if (pickedCity && !start && !pickedCities.includes(pickedCity))
-      setPickedCities([...pickedCities, pickedCity!]);
-  }, [pickedCities, pickedCity, start]);
+  }, [pickedCity, start, pickedCities]);
 
   return (
     <Flex alignContent="center" justifyContent="center">
       <ColorSchemeProvider colorScheme={scheme}>
         <DesignTokensProvider>
-        <Box color="default" minHeight="100vh" minWidth="100vw" paddingX={4}>
-          <Navigation
-            scheme={scheme}
-            setScheme={setScheme}
-          />
-          <Flex justifyContent="center">
-            <Box>
-              <Heading accessibilityLevel={1}>市町村ガチャ</Heading>
-              <Flex direction="column" gap={6}>
-                <Flex direction="row" alignItems="end" gap={4}>
-                  <Flex gap={2}>
-                    <Label htmlFor="isRandomPrefecture">
-                      <Text>ランダムで都道府県を選択</Text>
-                    </Label>
-                    <Switch
-                      id="isRandomPrefecture"
-                      name="isRandomPrefecture"
-                      switched={isRandomPrefecture}
-                      onChange={() => setIsRandomPrefecture(!isRandomPrefecture)}
+          <Box color="default" minHeight="100vh" minWidth="100vw" paddingX={4}>
+            <Navigation scheme={scheme} setScheme={setScheme} />
+            <Flex justifyContent="center">
+              <Box>
+                <Heading accessibilityLevel={1}>市町村ガチャ</Heading>
+                <Flex direction="column" gap={6}>
+                  <Flex direction="row" alignItems="end" gap={4}>
+                    <Flex gap={2}>
+                      <Label htmlFor="isRandomPrefecture">
+                        <Text>ランダムで都道府県を選択</Text>
+                      </Label>
+                      <Switch
+                        id="isRandomPrefecture"
+                        name="isRandomPrefecture"
+                        switched={isRandomPrefecture}
+                        onChange={() =>
+                          setIsRandomPrefecture(!isRandomPrefecture)
+                        }
+                      />
+                    </Flex>
+                    <ComboBox
+                      label="都道府県"
+                      id="prefecture"
+                      placeholder="都道府県を選択"
+                      inputValue={pickedPrefecture?.pref_name || ""}
+                      onSelect={(e) => selectPrefecture(e.item.value)}
+                      onClear={() => {
+                        setPickedPrefecture(undefined);
+                        setPickedCities([]);
+                      }}
+                      disabled={isRandomPrefecture}
+                      options={optionPrefectures}
                     />
                   </Flex>
-                  <ComboBox
-                    label="都道府県"
-                    id="prefecture"
-                    placeholder="都道府県を選択"
-                    inputValue={pickedPrefecture?.pref_name || ""}
-                    onSelect={(e) => selectPrefecture(e.item.value)}
-                    onClear={() => setPickedPrefecture(undefined)}
-                    disabled={isRandomPrefecture}
-                    options={optionPrefectures}
-                  />
+                  <Flex alignItems="end" gap={4}>
+                    <Button
+                      text="都道府県ランダム選択"
+                      disabled={!isRandomPrefecture || start}
+                      onClick={() => {
+                        setPickedCity(undefined);
+                        setPickedCities([]);
+                        setPrefectureStart(!prefectureStart);
+                        soundEffect();
+                      }}
+                    />
+                    <Button
+                      text={start ? "市町村ガチャストップ" : "市町村ガチャスタート"}
+                      onClick={() => {
+                        setStart(!start);
+                        soundEffect();
+                      }}
+                      color={"blue"}
+                      disabled={prefectureStart || availableCities.length === 0}
+                    />
+                    <IconButton
+                      accessibilityLabel="Toggle sound effect"
+                      size="md"
+                      bgColor={isPlaySound ? "gray" : "transparent"}
+                      icon={isPlaySound ? "music-on" : "music-off"}
+                      onClick={() => setIsPlaySound(!isPlaySound)}
+                    />
+                  </Flex>
                 </Flex>
-                <Flex alignItems="end" gap={4}>
-                  <Button
-                    text="都道府県ランダム選択"
-                    disabled={!isRandomPrefecture || start}
-                    onClick={() => {
-                      setPickedCity(undefined);
-                      setPrefectureStart(!prefectureStart);
-                      soundEffect();
-                    }}
-                  />
-                  <Button
-                    text={start ? "市町村ガチャストップ" : "市町村ガチャスタート"}
-                    onClick={() => {
-                      setStart(!start);
-                      soundEffect();
-                    }}
-                    color={"blue"}
-                    disabled={pickedCities.length === 15 || !pickedPrefecture || prefectureStart}
-                  />
-                  <IconButton
-                    accessibilityLabel="Toggle sound effect"
-                    size="md"
-                    bgColor={isPlaySound ? "gray" : "transparent"}
-                    icon={isPlaySound ? "music-on" : "music-off"}
-                    onClick={() => setIsPlaySound(!isPlaySound)}
-                  />
-                </Flex>
-              </Flex>
-              <Box marginTop={4}>
-                <TextField
-                  id="city"
-                  name="city"
-                  label="市町村"
-                  value={
-                    pickedPrefecture?.pref_name && pickedCity?.city_name
-                      ? `${pickedPrefecture.pref_name}${pickedCity.city_name}`
-                      : ""
-                  }
-                  onChange={() => { }}
+                <Box marginTop={4}>
+                  {start ? (
+                    <Box>
+                      <Label htmlFor="city-animation">
+                        <Text>市町村</Text>
+                      </Label>
+                      <Box
+                        borderStyle="sm"
+                        color="default"
+                        rounding={8}
+                        paddingX={4}
+                        paddingY={3}
+                        height={50}
+                        position="relative"
+                        overflow="hidden"
+                      >
+                        <Text
+                          color="subtle"
+                          weight="bold"
+                          size="300"
+                          // @ts-expect-error: className is not in the type definition
+                          className="gacha-animation-text"
+                        >
+                          <span>
+                            {pickedPrefecture?.pref_name}
+                            {pickedCity?.city_name}
+                          </span>
+                        </Text>
+                      </Box>
+                    </Box>
+                  ) : (
+                    <TextField
+                      id="city"
+                      name="city"
+                      label="市町村"
+                      value={
+                        pickedPrefecture?.pref_name && pickedCity?.city_name
+                          ? `${pickedPrefecture.pref_name}${pickedCity.city_name}`
+                          : ""
+                      }
+                      onChange={() => {}}
+                    />
+                  )}
+                </Box>
+                <PickedCities
+                  pickedCities={pickedCities}
+                  setPickedCity={setPickedCity}
+                  setPickedCities={setPickedCities}
                 />
               </Box>
-              <PickedCities
-                pickedCities={pickedCities}
-                setPickedCity={setPickedCity}
-                setPickedCities={setPickedCities}
-              />
-            </Box>
             </Flex>
           </Box>
         </DesignTokensProvider>

--- a/src/components/PickedCities.tsx
+++ b/src/components/PickedCities.tsx
@@ -13,9 +13,19 @@ export const PickedCities = ({ pickedCities, setPickedCity, setPickedCities }: P
       <Box>
         <Heading accessibilityLevel={2}>選ばれた市町村</Heading>
 
-        {pickedCities.map((city) => (
-          <Text key={city.city_code}>{city.name}</Text>
-        ))}
+        {[...pickedCities].reverse().map((city, index) =>
+          index === 0 ? (
+            <div key={city.city_code} className="newly-picked">
+              <Box color="infoWeak" padding={2} rounding={2} marginTop={2}>
+                <Text weight="bold">{city.name}</Text>
+              </Box>
+            </div>
+          ) : (
+            <Box key={city.city_code} paddingY={1} marginTop={2}>
+              <Text>{city.name}</Text>
+            </Box>
+          )
+        )}
       </Box>
 
       <Box marginTop={2}>

--- a/src/index.css
+++ b/src/index.css
@@ -9,3 +9,33 @@ body {
   min-width: 320px;
   min-height: 100vh;
 }
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.newly-picked {
+  animation: fadeIn 0.5s ease-out;
+}
+
+@keyframes vertical-scroll {
+  0% {
+    transform: translateY(-100%);
+  }
+  100% {
+    transform: translateY(100%);
+  }
+}
+
+.gacha-animation-text span {
+  animation: vertical-scroll 0.2s linear infinite alternate;
+  display: inline-block;
+  will-change: transform;
+}


### PR DESCRIPTION
ガチャ機能のユーザー体験とパフォーマンスを向上させるため、演出の追加とロジックの改善を行いました。

- ガチャ回転中にスロット風のアニメーションを追加
- 新しく選ばれた市町村がリストでハイライトされるように変更
- whileループを排除し、描画をブロックしない効率的なロジックにリファクタリング