### PR TITLE
build: tsconfigにnoEmit: trueを設定し不要なファイル出力を抑制

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -7,6 +7,7 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "composite": true,
+    "noEmit": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
pnpm build を実行した際に、tsc -b コマンドが src ディレクトリ内に .js や .d.ts ファイルを生成していた。

Viteプロジェクトでは tsc は型チェックにのみ使用するため、ファイルを出力する必要はない。

このコミットでは tsconfig.app.json の compilerOptions に noEmit: true を追加し、tsc による不要なファイルの出力を抑制する。